### PR TITLE
Fix default machine in local.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ For QEMU testing, you can stick with:
 MACHINE ?= "qemuarm"
 ```
 This means you’ll build for a generic ARM machine emulated by QEMU.
+Comment out the `MACHINE ??= "qemux86-64"` line in the same file so this is the only default.
 
 ### Step 2: Start the build!
 ```bash

--- a/conf/local.conf
+++ b/conf/local.conf
@@ -36,7 +36,8 @@ MACHINE ?= "qemuarm"
 #MACHINE ?= "edgerouter"
 #
 # This sets the default machine to be qemux86-64 if no other machine is selected:
-MACHINE ??= "qemux86-64"
+# Commented out to avoid conflicting defaults
+#MACHINE ??= "qemux86-64"
 
 #
 # Where to place downloads


### PR DESCRIPTION
## Summary
- comment out the qemux86-64 default machine in `conf/local.conf`
- note the change in the README under build configuration

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68622d37ef3483298661e657ea5125c0